### PR TITLE
bugfix(gulp): fix getModules on windows

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -125,7 +125,7 @@ gulp.task('packages:get', async () => {
 gulp.task('packages:ci', async () => {
   const modules = getModules();
   const parts = [];
-
+  
   const packages = Object.keys(modules);
   for (let i = 0; i < packages.length; i++) {
     const currentPackage = process.platform === 'win32' ? packages[i].replace('/', '\\') : packages[i];
@@ -138,18 +138,20 @@ gulp.task('packages:ci', async () => {
 
 const getModules = () => {
   const gitmodules = fs.readFileSync(`${__dirname}/.gitmodules`, { encoding: 'utf8' });
-  const modulesArray: any = gitmodules.split('[').filter(m => !!m).map((m, i) => m.split(`
-	`).map((p, i) => !i ? p.split(' ')[1].slice(1, process.platform === 'win32' ? -3 : -2) : p.replace('\n', '').split(' = ')));
+  console.log(gitmodules);
+  const regex = /\[submodule ?"(?<submodule_name>.+?)"]\s+path ?= ?(?<path>.+?)\s+url ?= ?(?<url>.+?)\s/gm;
   const modules = {};
-  for (let m = 0; m < modulesArray.length; m++) {
-    const ma = modulesArray[m];
-    const mod = modules[ma[0]] = {};
-    const mas = ma.slice(1);
-    for (let k = 0; k < mas.length; k++) {
-      const field = mas[k];
-      mod[field[0]] = field[1];
+
+  let submodule;
+
+  while ((submodule = regex.exec(gitmodules)) !== null) {
+    const {submodule_name, path, url} = submodule.groups
+    modules[submodule_name] = {
+      path,
+      url,
     }
   }
+  
   return modules;
 }
 

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -138,7 +138,6 @@ gulp.task('packages:ci', async () => {
 
 const getModules = () => {
   const gitmodules = fs.readFileSync(`${__dirname}/.gitmodules`, { encoding: 'utf8' });
-  console.log(gitmodules);
   const regex = /\[submodule ?"(?<submodule_name>.+?)"]\s+path ?= ?(?<path>.+?)\s+url ?= ?(?<url>.+?)\s/gm;
   const modules = {};
 


### PR DESCRIPTION
getModules return on windows
```
{
  'packages/hasura"': {
    path: 'packages/hasura\r',
    url: 'https://github.com/deep-foundation/hasura.git\r'
  },
 ...
}
```
Error: unterminated quoted string
